### PR TITLE
Remove `concurrently` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"esbuild ./demo/sw.js --bundle --outfile=./demo/bundled-sw.js --watch --format=iife\" \"cd demo && npx http-server -o\"",    
+    "dev": "esbuild ./demo/sw.js --bundle --outfile=./demo/bundled-sw.js --watch --format=iife --servedir=demo",
     "start": "node --watch dev.js",
     "test": "node --watch tests/tests.js"
   },
@@ -30,7 +30,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "concurrently": "^8.2.0",
     "esbuild": "^0.19.0"
   }
 }


### PR DESCRIPTION
I don't really see why `concurrently` package is needed since `esbuild` can also do serving: https://esbuild.github.io/api/#serve

Removing it saves about 13MB in node modules: https://packagephobia.com/result?p=concurrently